### PR TITLE
Error potencial al cargar una llave privada sin contraseña

### DIFF
--- a/src/main/java/mx/bigdata/sat/security/PrivateKeyLoader.java
+++ b/src/main/java/mx/bigdata/sat/security/PrivateKeyLoader.java
@@ -80,11 +80,11 @@ public class PrivateKeyLoader implements KeyLoader {
 
 
     private byte[] extractProtectedPrivateKey(InputStream privateKeyInputStream, String keyPassword) {
-        byte[] bytes = null;
+        byte[] bytes;
 
         try {
             if(keyPassword == null) {
-                ByteStreams.toByteArray(privateKeyInputStream);
+                bytes = ByteStreams.toByteArray(privateKeyInputStream);
             } else {
                 bytes = new PKCS8Key(privateKeyInputStream, keyPassword.toCharArray()).getDecryptedBytes();
             }


### PR DESCRIPTION
Existe un error al intentar cargar una llave privada sin contraseña. La variable bytes no obtiene el valor de la lectura de bytes del InputStream de la llave privada. Se aplica ajuste en código para asignar tal valor.
